### PR TITLE
Update .gitignore to ignore certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ go/pkg
 kubernetes/.packaged/
 kubernetes/cray-hms-meds/helm
 .idea/
+
+# Prevent certificates from getting checked in
+*.ca
+*.cer
+*.crt
+*.csr
+*.key
+*.pem


### PR DESCRIPTION
Update .gitignore to ignore certificates to help prevent check in of sensitive files in the future.