### PR TITLE
CASMHMS-5608 Update internal HMS documentation for Helm CT tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2021] Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -66,9 +66,3 @@ This will set up an environment with one dummy endpoint, named `x1000c1s1b0`.  I
 `curl  -d '{"Xname":"x1000","Type":"comptype_cabinet","Class":"Mountain","TypeString":"Cabinet","ExtraProperties":{"Networks":{"cn":{"HMN":{"CIDR":"172.26.0.1/22","Gateway":"172.26.0.254","VLan":3001},"NMN":{"CIDR":"10.100.0.1/22","Gateway":"10.100.3.254","VLan":2001}},"ncn":{}}}}' http://cray-sls:8376/v1/hardware`
 
 Note that on the mac, docker containers do not resolve, so use `localhost` as the hostname to contact.
-
-### MEDS CT Testing
-
-This repository builds and publishes hms-meds-ct-test RPMs along with the service itself containing tests that verify MEDS on the
-NCNs of live Shasta systems. The tests require the hms-ct-test-base RPM to also be installed on the NCNs in order to execute.
-The version of the test RPM installed on the NCNs should always match the version of MEDS deployed on the system.


### PR DESCRIPTION
### Summary and Scope

- Remove CT testing section of README since we're now using Helm-based tests instead of RPMs and the former MEDS CT tests required Kubernetes which won't run inside the service mesh.
- Assorted README cleanup.

### Issues and Related PRs

* Partially resolves CASMHMS-5608.

### Testing

- Rendered README updates and viewed them to verify that they look as expected.
- No testing performed due to documentation change only.

Was a fresh Install tested? N/A
Was an Upgrade tested? N/A
Was a Downgrade tested? N/A

### Risks and Mitigations

None, README change only.